### PR TITLE
Add table of contents

### DIFF
--- a/content/tjenester.md
+++ b/content/tjenester.md
@@ -2,14 +2,9 @@
 template = "page.html"
 title = "Tjenester"
 description = "Oversikt over de ulike tjenestene friByte har å tilby." 
+[extra]
+enable_toc = true
 +++
-
-- [Webhotell](#webhotell)
-- [Capture the Flag](#capture-the-flag-ctf)
-- [Intern kommunikasjon](#intern-kommunikasjon)
-- [Interne ressurser](#interne-ressurser)
-- [Utvikling](#utvikling)
-- [Spesialiserte tjenester](#spesialiserte-tjenester)
 
 ## Webhotell
 

--- a/content/tjenester.md
+++ b/content/tjenester.md
@@ -6,7 +6,7 @@ description = "Oversikt over de ulike tjenestene friByte har å tilby."
 
 - [Webhotell](#webhotell)
 - [Capture the Flag](#capture-the-flag-ctf)
-- [Intern kommunikasjon)](#intern-kommunikasjon)
+- [Intern kommunikasjon](#intern-kommunikasjon)
 - [Interne ressurser](#interne-ressurser)
 - [Utvikling](#utvikling)
 - [Spesialiserte tjenester](#spesialiserte-tjenester)

--- a/templates/page.html
+++ b/templates/page.html
@@ -8,5 +8,32 @@
 
 {% block content %}
   <h1>{{ page.title }}</h1>
+  {% if page.extra.enable_toc %}
+  <ul>
+    {% for item in page.toc %}
+      <li>
+        <a href="{{ item.permalink }}">{{ item.title }}</a>
+        {% if item.children %}
+          <ul>
+            {% for child in item.children %}
+              <li>
+                <a href="{{ child.permalink }}">{{ child.title }}</a>
+                {% if child.children %}
+                  <ul>
+                    {% for grand_child in child.children %}
+                      <li>
+                        <a href="{{ grand_child.permalink }}">{{ grand_child.title }}</a>
+                      </li>
+                    {% endfor %}
+                  </ul>
+                {% endif %}
+              </li>
+            {% endfor %}
+          </ul>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+  {% endif %}
   {{ page.content | safe }}
 {% endblock content %}


### PR DESCRIPTION
Added automatic table of contents option to `page.html`.

No more typos. You simply enable it in the front-matter.
