### PR TITLE
fix: Theme switcher jump on page load

### DIFF
--- a/static/js/detect-theme.js
+++ b/static/js/detect-theme.js
@@ -1,0 +1,23 @@
+// determines if the user has a set theme
+function detectColorScheme() {
+  let theme = "light"; //default to light
+
+  // local storage is used to override OS theme settings
+  if (localStorage.getItem("theme")) {
+    if (localStorage.getItem("theme") == "dark") {
+      theme = "dark";
+    }
+  } else if (!window.matchMedia) {
+    // matchMedia method not supported
+    return false;
+  } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
+    // OS theme setting detected as dark
+    theme = "dark";
+  }
+
+  // dark theme preferred, set document with a `data-theme` attribute
+  if (theme == "dark") {
+    document.documentElement.setAttribute("data-theme", "dark");
+  }
+}
+window.onload = detectColorScheme();

--- a/static/js/theme.js
+++ b/static/js/theme.js
@@ -1,51 +1,27 @@
 // identify the toggle switch HTML element
-const toggleSwitch = document.querySelector("#checkbox_theme")
+const toggleSwitch = document.querySelector("#checkbox_theme");
 
 // function that changes the theme, and sets a localStorage variable to track the theme between page loads
 function switchTheme(e) {
   if (e.target.checked) {
-    localStorage.setItem("theme", "dark")
-    document.documentElement.setAttribute("data-theme", "dark")
-    toggleSwitch.checked = true
+    localStorage.setItem("theme", "dark");
+    document.documentElement.setAttribute("data-theme", "dark");
+    toggleSwitch.checked = true;
   } else {
-    localStorage.setItem("theme", "light")
-    document.documentElement.setAttribute("data-theme", "light")
-    toggleSwitch.checked = false
+    localStorage.setItem("theme", "light");
+    document.documentElement.setAttribute("data-theme", "light");
+    toggleSwitch.checked = false;
   }
 }
 
 // listener for changing themes
-toggleSwitch.addEventListener("change", switchTheme, false)
+toggleSwitch.addEventListener("change", switchTheme, false);
 
 function isDarkTheme() {
   // pre-check the dark-theme checkbox if dark-theme is set
   if (document.documentElement.getAttribute("data-theme") == "dark") {
-    toggleSwitch.checked = true
+    toggleSwitch.checked = true;
   }
 }
 
-window.onload = detectColorScheme()
-window.onload = isDarkTheme()
-
-// determines if the user has a set theme
-function detectColorScheme() {
-  let theme = "light" //default to light
-
-  // local storage is used to override OS theme settings
-  if (localStorage.getItem("theme")) {
-    if (localStorage.getItem("theme") == "dark") {
-      theme = "dark"
-    }
-  } else if (!window.matchMedia) {
-    // matchMedia method not supported
-    return false
-  } else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-    // OS theme setting detected as dark
-    theme = "dark"
-  }
-
-  // dark theme preferred, set document with a `data-theme` attribute
-  if (theme == "dark") {
-    document.documentElement.setAttribute("data-theme", "dark")
-  }
-}
+window.onload = isDarkTheme();

--- a/templates/base/default.html
+++ b/templates/base/default.html
@@ -1,7 +1,6 @@
 {% import "macros.html" as macros %}
 <html lang="{{ lang }}">
   <head>
-
       {% set logo = get_url(path="logo.svg") %}
       {% set cover = get_url(path="img/cover.png") %}
 
@@ -38,6 +37,9 @@
 
       <link href="{{ get_url(path="rss.xml") | safe }}" rel="feed">
       <title>{{ title }}</title>
+      <script defer>
+        {{ load_data(path="js/detect-theme.js") | safe }}
+      </script>
   </head>
 
   <body>


### PR DESCRIPTION
When you go to a new page the theme switcher doesn't toggle anymore, it really
remembers your prefeered theme.
