### PR TITLE
fix: link in tjenester.en.md

### DIFF
--- a/content/tjenester.en.md
+++ b/content/tjenester.en.md
@@ -56,7 +56,7 @@ There are lots of alternatives, and friByte helps you find the best fit for your
 
 ## Development
 
-We like to program at friByte, and it's likely that we can develop what you need. Don't hesitate to (send us an e-mail)[mailto:post@fribyte.no] to find out!
+We like to program at friByte, and it's likely that we can develop what you need. Don't hesitate to [send us an e-mail](mailto:post@fribyte.no) to find out!
 
 ## Specialized services
 


### PR DESCRIPTION
Swap use of square brackets and parenthesis to make link correct markdown link syntax.

Mirroring the fix in 4a7f6acae25c2ca34cbcd4da8f9fd3461b49dc47