### PR TITLE
feat: Add `is_featured` prop to news posts

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -49,6 +49,7 @@ foresporsel = "Forespørsel"
 dear_fribyte = "Kjære friByte"
 soknad = "Søknad"
 stoettet_av = "Støttet av"
+skrevet_av = "Skrevet av"
 
 [languages.en]
 build_search_index = true
@@ -84,6 +85,7 @@ foresporsel = "Request"
 dear_fribyte = "Dear friByte"
 soknad = "Application"
 stoettet_av = "Supported by"
+skrevet_av = "Written by"
 
 [extra]
 nav = [

--- a/config.toml
+++ b/config.toml
@@ -110,7 +110,6 @@ email_join = "bli-medlem@fribyte.no"
 email_support = "hjelp@fribyte.no"
 
 boskonf_live = false
-custom_hero = true
 
 [link_checker]
 # Skip link checking for external URLs that start with these prefixes

--- a/content/nyheter/2024-02-19-arets-studentbedrift.en.md
+++ b/content/nyheter/2024-02-19-arets-studentbedrift.en.md
@@ -1,0 +1,27 @@
++++
+title = 'We won "Student Organization of the Year 2023"! 🎉'
+date = 2024-02-19
+description = "We walked away with victory!!💫"
+[extra]
+author = "Nick James Hipol"
++++
+
+<div class="pyro-container">
+  <div class="pyro">
+    <div class="before"></div>
+    <div class="after"></div>
+  </div>
+</div>
+
+On February 15th we attended the Student Life Conference at Kvarteret. This
+year's student organization was named, and we walked away with victory!!💫 This
+was incredibly fun!
+
+With these funds, we can improve our equipment and services to provide an even
+better experience for all the organizations we serve. Many thanks to the jury
+for choosing us, and special thanks to [Sammen Bergen], [Sammen Studentliv] og
+[VtVest]!
+
+[Sammen Bergen]: https://www.instagram.com/sammenbergen/
+[Sammen Studentliv]: https://www.instagram.com/sammenstudentliv/
+[VtVest]: https://www.instagram.com/vtvest/

--- a/content/nyheter/2024-02-19-arets-studentbedrift.en.md
+++ b/content/nyheter/2024-02-19-arets-studentbedrift.en.md
@@ -2,8 +2,7 @@
 title = 'We won "Student Organization of the Year 2023"! 🎉'
 date = 2024-02-19
 description = "We walked away with victory!!💫"
-[extra]
-author = "Nick James Hipol"
+authors = ["Nick James Hipol"]
 +++
 
 <div class="pyro-container">

--- a/content/nyheter/2024-02-19-arets-studentbedrift.en.md
+++ b/content/nyheter/2024-02-19-arets-studentbedrift.en.md
@@ -3,6 +3,8 @@ title = 'We won "Student Organization of the Year 2023"! 🎉'
 date = 2024-02-19
 description = "We walked away with victory!!💫"
 authors = ["Nick James Hipol"]
+[extra]
+is_featured = true
 +++
 
 <div class="pyro-container">

--- a/content/nyheter/2024-02-19-arets-studentbedrift.md
+++ b/content/nyheter/2024-02-19-arets-studentbedrift.md
@@ -1,0 +1,29 @@
++++
+title = 'Vi vant "Årets Studentorganisasjon 2023"! 🎉'
+date = 2024-02-19
+description = "Vi gikk av med seieren!!💫"
+[taxonomies]
+categories = ["Nyheter"]
+[extra]
+author = "Nick James Hipol"
++++
+
+<div class="pyro-container">
+  <div class="pyro">
+    <div class="before"></div>
+    <div class="after"></div>
+  </div>
+</div>
+
+Den 15. februar var vi på Studentlivkonferansen på Det Akademiske Kvarter. Her
+ble årets studentorganisasjon 2023 kåret, og vi gikk av med seieren!!💫 Dette
+var helt utrolig gøy!
+
+Med disse midlene kan vi forbedre utstyret og tjenestene våre for å gi en enda
+bedre opplevelse for alle organisasjonene vi betjener. Tusen takk til juryen for
+at de har valgt oss, og tusen takk til [Sammen Bergen], [Sammen Studentliv] og
+[VtVest]!
+
+[Sammen Bergen]: https://www.instagram.com/sammenbergen/
+[Sammen Studentliv]: https://www.instagram.com/sammenstudentliv/
+[VtVest]: https://www.instagram.com/vtvest/

--- a/content/nyheter/2024-02-19-arets-studentbedrift.md
+++ b/content/nyheter/2024-02-19-arets-studentbedrift.md
@@ -2,10 +2,9 @@
 title = 'Vi vant "Årets Studentorganisasjon 2023"! 🎉'
 date = 2024-02-19
 description = "Vi gikk av med seieren!!💫"
+authors = ["Nick James Hipol"]
 [taxonomies]
 categories = ["Nyheter"]
-[extra]
-author = "Nick James Hipol"
 +++
 
 <div class="pyro-container">

--- a/content/nyheter/2024-02-19-arets-studentbedrift.md
+++ b/content/nyheter/2024-02-19-arets-studentbedrift.md
@@ -5,6 +5,8 @@ description = "Vi gikk av med seieren!!💫"
 authors = ["Nick James Hipol"]
 [taxonomies]
 categories = ["Nyheter"]
+[extra]
+is_featured = true
 +++
 
 <div class="pyro-container">

--- a/content/nyheter/_index.en.md
+++ b/content/nyheter/_index.en.md
@@ -1,0 +1,7 @@
++++
+title = "News"
+description = "News overview, here you can find news and status updates"
+template = "nyheter.html"
+page_template = "post.html"
+sort_by = "date"
++++

--- a/sass/components/_banner.scss
+++ b/sass/components/_banner.scss
@@ -5,7 +5,6 @@
   z-index: 1;
   opacity: 1;
   font-family: $font-family-mono;
-  text-transform: lowercase;
   transition: all 350ms ease;
 
   &:hover {
@@ -32,14 +31,4 @@
 
 .banner-container {
   display: block;
-
-  &.center {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-
-    & > * {
-      margin-top: 1em;
-    }
-  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,9 +6,13 @@
 {% endblock head %}
 
 {% block content %}
-  {% set news = get_section(path="nyheter/_index.md") %}
+  {% set_global newsPath = "nyheter/_index.md" %}
+  {% if lang == "en" %}
+    {% set_global newsPath = "nyheter/_index.en.md" %}
+  {% endif %}
+  {% set news = get_section(path=newsPath) %}
   {% set featured_news = news.pages | sort(attribute="date") | reverse | filter(attribute="extra.is_featured", value=true) %}
-  {% if featured_news and lang == 'no' %}
+  {% if featured_news %}
     {% set post = featured_news[0] %}
     <div class="banner-container center">
       <h2 class="banner">{{ post.title }}</h2>

--- a/templates/index.html
+++ b/templates/index.html
@@ -7,78 +7,34 @@
 
 {% block content %}
   <section class="hero">
-    {% set custom_hero = config.extra.custom_hero %}
-
-    {% if custom_hero %}
-      <div class="pyro-container">
-        <div class="pyro">
-          <div class="before"></div>
-          <div class="after"></div>
-        </div>
-      </div>
-      {% if lang == 'no' %}
-        <div class="banner-container center">
-          <h2 class="banner">Vi vant Årets Studentorganisasjon 2023!!🎉</h2>
-        </div>
-        <br/>
-        <p>
-          15. februar var vi på Studentlivkonferansen på Det Akademiske Kvarter. Her ble årets studentorganisasjon 2023 kåret, og vi gikk av med seieren!!💫
-          Dette var helt utrolig gøy! 
-        </p>
-        <p>
-          Med disse midlene kan vi forbedre utstyret og tjenestene våre for å gi en enda bedre opplevelse for alle organisasjonene vi betjener.
-          Tusen takk til juryen for at de har valgt oss, og tusen takk til 
-          <a href="https://www.instagram.com/sammenbergen/" target="_blank">Sammen Bergen</a>, 
-          <a href="https://www.instagram.com/sammenstudentliv/ target="_blank"">Sammen Studentliv</a> og 
-          <a href="https://www.instagram.com/vtvest/" target="_blank">VtVest</a> for en fantastisk konferanse! 😍🙌🏽
-        </p>
-      {% elif lang == 'en' %}
-        <div class="banner-container center">
-          <h2 class="banner">We won Student Organization of the Year 2023!!🎉</h2>
-        </div>
-        <br/>
-        <p>
-          On 15 February we attended the Student Life Conference at Kvarteret. This year's student organization was named, and we walked away with victory!!💫
-          This was incredibly fun!
-        </p>
-        <p>
-          With these funds, we can improve our equipment and services to provide an even better experience for all the organizations we serve.
-          Many thanks to the jury for choosing us, and many thanks to you
-          <a href="https://www.instagram.com/sammenbergen/" target="_blank">Sammen Bergen</a>, 
-          <a href="https://www.instagram.com/sammenstudentliv/" target="_blank">Sammen Studentliv</a> and 
-          <a href="https://www.instagram.com/vtvest/" target="_blank">VtVest</a> for a fantastic conference! 😍🙌🏽
-        </p>
-      {% endif %}
-    {% else %}
-      <style>
-        [data-theme="dark"] #illustration {
-          background: url({{get_url(path="/img/illustrations/dark_undraw_server.svg") | safe }}) center / cover no-repeat;
-          background-size: contain;
-        }
+    <style>
+      [data-theme="dark"] #illustration {
+        background: url({{get_url(path="/img/illustrations/dark_undraw_server.svg") | safe }}) center / cover no-repeat;
+        background-size: contain;
+      }
+      #illustration {
+        width: 100%;
+        height: 10vh;
+        display: block;
+        position: relative;
+        background: url({{get_url(path="/img/illustrations/undraw_server.svg") | safe }}) center / cover no-repeat;
+        background-size: contain;
+      }
+      @media (min-width: 992px) {
         #illustration {
           width: 100%;
           height: 20vh;
-          display: block;
-          position: relative;
-          background: url({{get_url(path="/img/illustrations/undraw_server.svg") | safe }}) center / cover no-repeat;
-          background-size: contain;
         }
-        @media (min-width: 992px) {
-          #illustration {
-            width: 100%;
-            height: 60vh;
-          }
-        }
-      </style>
-      <div id="illustration"></div>
+      }
+    </style>
+    <div id="illustration"></div>
 
-      <p>
-        {{ config.description }}
-      </p>
-      <div class="button-container center">
-        <a href="{{ get_url(path="@/bli-medlem.md") }}" class="btn primary center underscore">{{ trans(key="bli_medlem", lang=lang) }}</a>
-      </div>
-    {% endif %}
+    <p>
+      {{ config.description }}
+    </p>
+    <div class="button-container center">
+      <a href="{{ get_url(path="@/bli-medlem.md") }}" class="btn primary center underscore">{{ trans(key="bli_medlem", lang=lang) }}</a>
+    </div>
   </section>
 
   {% if lang == 'no' %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -6,36 +6,46 @@
 {% endblock head %}
 
 {% block content %}
-  <section class="hero">
-    <style>
-      [data-theme="dark"] #illustration {
-        background: url({{get_url(path="/img/illustrations/dark_undraw_server.svg") | safe }}) center / cover no-repeat;
-        background-size: contain;
-      }
-      #illustration {
-        width: 100%;
-        height: 10vh;
-        display: block;
-        position: relative;
-        background: url({{get_url(path="/img/illustrations/undraw_server.svg") | safe }}) center / cover no-repeat;
-        background-size: contain;
-      }
-      @media (min-width: 992px) {
+  {% set news = get_section(path="nyheter/_index.md") %}
+  {% set featured_news = news.pages | sort(attribute="date") | reverse | filter(attribute="extra.is_featured", value=true) %}
+  {% if featured_news and lang == 'no' %}
+    {% set post = featured_news[0] %}
+    <div class="banner-container center">
+      <h2 class="banner">{{ post.title }}</h2>
+    </div>
+    {{ post.content | safe  }}
+  {% else %}
+    <section class="hero">
+      <style>
+        [data-theme="dark"] #illustration {
+          background: url({{get_url(path="/img/illustrations/dark_undraw_server.svg") | safe }}) center / cover no-repeat;
+          background-size: contain;
+        }
         #illustration {
           width: 100%;
-          height: 20vh;
+          height: 10vh;
+          display: block;
+          position: relative;
+          background: url({{get_url(path="/img/illustrations/undraw_server.svg") | safe }}) center / cover no-repeat;
+          background-size: contain;
         }
-      }
-    </style>
-    <div id="illustration"></div>
+        @media (min-width: 992px) {
+          #illustration {
+            width: 100%;
+            height: 20vh;
+          }
+        }
+      </style>
+      <div id="illustration"></div>
 
-    <p>
-      {{ config.description }}
-    </p>
-    <div class="button-container center">
-      <a href="{{ get_url(path="@/bli-medlem.md") }}" class="btn primary center underscore">{{ trans(key="bli_medlem", lang=lang) }}</a>
-    </div>
-  </section>
+      <p>
+        {{ config.description }}
+      </p>
+      <div class="button-container center">
+        <a href="{{ get_url(path="@/bli-medlem.md") }}" class="btn primary center underscore">{{ trans(key="bli_medlem", lang=lang) }}</a>
+      </div>
+    </section>
+  {% endif %}
 
   {% if lang == 'no' %}
     <section class="contact">
@@ -66,7 +76,6 @@
 
     <section class="latest-news">
       <h2>Siste nytt</h2>
-      {% set news = get_section(path="nyheter/_index.md") %}
       <ul>
         {% for post in news.pages | slice(end=5) | sort(attribute="date") | reverse %}
         <li>

--- a/templates/index.html
+++ b/templates/index.html
@@ -23,7 +23,7 @@
         }
         #illustration {
           width: 100%;
-          height: 10vh;
+          height: 20vh;
           display: block;
           position: relative;
           background: url({{get_url(path="/img/illustrations/undraw_server.svg") | safe }}) center / cover no-repeat;
@@ -32,7 +32,7 @@
         @media (min-width: 992px) {
           #illustration {
             width: 100%;
-            height: 20vh;
+            height: 40vh;
           }
         }
       </style>

--- a/templates/post.html
+++ b/templates/post.html
@@ -12,7 +12,7 @@
     <span class="date">{{ page.date | date(format="%b %d, %Y") }}</span>
     {% if page.authors | length > 0 %}
       -
-      <span class="author">Skrevet av {{ page.authors | join(sep=", ") }}</span>
+      <span class="author">{{ trans(key="skrevet_av", lang=lang) }} {{ page.authors | join(sep=", ") }}</span>
     {% endif %}
 </div>
   {{ page.content | safe }}


### PR DESCRIPTION
La til `is_featured` prop til nyhetsinnlegg slik at de kan bli fremhevet på
forsiden. Da trenger man ikke å oppdatere forsiden hver gang det vil være behov
for å fremheve en sak, da skriver man heller et innlegg som vil bli bevart på
nettsiden framover i tid.

Flyttet også "Vi vant "Årets Studentorganisasjon 2023"! 🎉" til eget
nyhetsinnlegg.
