### PR TITLE
refactor: Use Zolas built-in `authors` prop

### DIFF
--- a/content/nyheter/2021-05-09-ny-nettside.md
+++ b/content/nyheter/2021-05-09-ny-nettside.md
@@ -2,24 +2,30 @@
 title = "Ny nettside - re-lansering!"
 date = 2021-05-09
 description = "friByte har fornyet seg! H20 begynte en intern omstrukturering og gjennoppliving."
+authors = ["Tim Hårek Andreassen"]
 [taxonomies]
 categories = ["Nyheter"] 
-[extra]
-author = "Tim Hårek Andreassen"
 +++
 
-Vi har fornyet oss! Siden forrige semester høsten 2020 har friByte undergått omstrukturering internt, vi holder på å fornye tjenestene vi tilbyr, og med dette har vi da fått en helt ny nettside.
+Vi har fornyet oss! Siden forrige semester høsten 2020 har friByte undergått
+omstrukturering internt, vi holder på å fornye tjenestene vi tilbyr, og med
+dette har vi da fått en helt ny nettside.
 
-Vi er for tiden på jakt etter flere medlemmer! Hvis du har lyst å bli med oss å lære nye (og gamle) ting om hvordan man verter ulike tjenester eller generelt hvordan man "flytter inn" i terminalen, anbefaler vi å sjekke ut vår [bli medlem](/bli-medlem)-side!
+Vi er for tiden på jakt etter flere medlemmer! Hvis du har lyst å bli med oss å
+lære nye (og gamle) ting om hvordan man verter ulike tjenester eller generelt
+hvordan man "flytter inn" i terminalen, anbefaler vi å sjekke ut vår
+[bli medlem](/bli-medlem)-side!
 
 ## Abonner via RSS
 
-Hvis du er kunde hos oss eller bare interessert i hva som skjer i friByte, og ønsker å få med deg siste nytt som nyheter og driftsmeldinger anbefaler vi å abonnere via RSS. Vi kommer til å prøve å være mye mer aktiv!
+Hvis du er kunde hos oss eller bare interessert i hva som skjer i friByte, og
+ønsker å få med deg siste nytt som nyheter og driftsmeldinger anbefaler vi å
+abonnere via RSS. Vi kommer til å prøve å være mye mer aktiv!
 
 ## Lurer du på noe?
 
-Er det noe du lurer på angående friByte, nettsiden, tjenestene vi tilbyr eller noe annet relatert? Ta kontakt med oss i dag!
-
+Er det noe du lurer på angående friByte, nettsiden, tjenestene vi tilbyr eller
+noe annet relatert? Ta kontakt med oss i dag!
 
 <div class="button-container center">
     <a href="/bli-medlem" class="btn primary center">Bli medlem</a>

--- a/content/nyheter/2022-01-12-jubileum.md
+++ b/content/nyheter/2022-01-12-jubileum.md
@@ -4,8 +4,7 @@ updated = 2022-06-21
 title = "20 års jubileum"
 description = "friByte feirer 20 år i 2022." 
 aliases = ["/jubileum"]
-[extra]
-author = "Mathias Husebø"
+authors = ["Mathias Husebø"]
 +++
 
 Dere trodde kanskje vi var dø? Nei da, vi lever enda!

--- a/content/nyheter/2022-02-08-jubileum-ctf.md
+++ b/content/nyheter/2022-02-08-jubileum-ctf.md
@@ -3,12 +3,11 @@ date = 2022-02-08
 updated = 2022-06-21
 title = "Jubileum CTF"
 aliases = ["/ctf"]
-[extra]
-author = "Rolf Martin Glomsrud"
+authors = ["Rolf Martin Glomsrud"]
 +++
 
-I anledning friByte sitt [20 års jubileum](@/nyheter/2022-01-12-jubileum.md) arrangerer vi Capture The
-Flag for alle informatikk studenter på UiB.
+I anledning friByte sitt [20 års jubileum](@/nyheter/2022-01-12-jubileum.md)
+arrangerer vi Capture The Flag for alle informatikk studenter på UiB.
 
 - Sted:
   [Aktivt rom (2+3), Høyteknologisenteret](https://link.mazemap.com/KMpUK7v7)

--- a/content/nyheter/2022-02-20-jubileumsplan.md
+++ b/content/nyheter/2022-02-20-jubileumsplan.md
@@ -2,10 +2,9 @@
 title = "Plan for jubileumsuken!"
 date = 2022-02-20
 description = "friByte fyller år 24. februar! I den anledning har vi planlagt et par arrangementer den uken."
+authors = ["Christian Kårbø Engelsen"]
 [taxonomies]
 categories = ["Nyheter"]
-[extra]
-author = "Christian Kårbø Engelsen"
 +++
 
 friByte blir 20 år den 24. februar og har dedikert uken til et par arrangementer

--- a/content/nyheter/2023-01-24-instagram.md
+++ b/content/nyheter/2023-01-24-instagram.md
@@ -2,10 +2,9 @@
 title = "Instagram konto!"
 date = 2023-01-24
 description = "Vi har fått en Instagram konto"
+authors = ["Daniel Liland"]
 [taxonomies]
 categories = ["Nyheter"]
-[extra]
-author = "Daniel Liland"
 +++
 
 Vi har opprettet en Instagram konto!

--- a/content/nyheter/2023-02-08-ny-tech-fra-machina/index.md
+++ b/content/nyheter/2023-02-08-ny-tech-fra-machina/index.md
@@ -2,10 +2,9 @@
 title = "Vi har fått donert hardware!"
 date = 2023-02-08
 description = ""
+authors = ["Daniel Lilad"]
 [taxonomies]
 categories = ["Nyheter"]
-[extra]
-author = "Daniel Lilad"
 +++
 
 Vi har vært så heldige og fått cutting-edge hardware fra Machina! De har gitt

--- a/content/nyheter/2023-02-20-ctf.md
+++ b/content/nyheter/2023-02-20-ctf.md
@@ -2,10 +2,9 @@
 title = "CTF 2023 14. mars"
 date = 2023-02-20
 description = "Nå kommer vår årlige CTF"
+authors = ["Daniel Liland"]
 [taxonomies]
 categories = ["Nyheter"]
-[extra]
-author = "Daniel Liland"
 +++
 
 Velkommen til CTF!

--- a/content/nyheter/2023-03-31-nye-servere/index.md
+++ b/content/nyheter/2023-03-31-nye-servere/index.md
@@ -2,10 +2,9 @@
 title = "Nye servere fra Comtec!"
 date = 2023-03-31
 description = ""
+authors = ["Daniel Lilad"]
 [taxonomies]
 categories = ["Nyheter"]
-[extra]
-author = "Daniel Lilad"
 +++
 
 Vi har nettopp hentet tre beist av servere fra Comtec!

--- a/content/nyheter/2023-10-03-BOSKonferanse2023.md
+++ b/content/nyheter/2023-10-03-BOSKonferanse2023.md
@@ -2,10 +2,9 @@
 title = "Bergen Open Source 2023"
 date = 2023-10-03
 description = "BOS Konferansen - Bergens første tech-konferanse arrangert av friByte"
+authors = ["Mathias Haugsbø"]
 [taxonomies]
 categories = ["Nyheter"]
-[extra]
-author = "Mathias Haugsbø"
 +++
 
 # friByte sin første tech konferanse!
@@ -19,4 +18,5 @@ medlemmer i friByte og andre kjente folk i bransjen.
 Vi håper på at dette blir en årlig konferanse med rundt 100 deltakere, og vi
 håper du vil være en av dem!
 
-Årets konferanse ble en stor suksess! Se opptak av foredragene på [https://boskonf.no/arkiv/2023/](https://boskonf.no/arkiv/2023/).
+Årets konferanse ble en stor suksess! Se opptak av foredragene på
+[https://boskonf.no/arkiv/2023/](https://boskonf.no/arkiv/2023/).

--- a/content/nyheter/2024-02-20-ctf24/index.md
+++ b/content/nyheter/2024-02-20-ctf24/index.md
@@ -2,10 +2,9 @@
 title = "CTF 2024 14. mars"
 date = 2024-02-20
 description = "Endelig kommer vår årlige CTF!"
+authors = ["Sigve Skåvik"]
 [taxonomies]
 categories = ["Nyheter"]
-[extra]
-author = "Sigve Skåvik"
 +++
 
 <img src="/nyheter/ctf24/CTF logo mHeltSikker.png" width="250" /> <br>

--- a/templates/post.html
+++ b/templates/post.html
@@ -10,9 +10,9 @@
 <h1>{{ page.title }}</h1>
 <div class="metadata">
     <span class="date">{{ page.date | date(format="%b %d, %Y") }}</span>
-    {% if page.extra.author %}
+    {% if page.authors | length > 0 %}
       -
-      <span class="author">Skrevet av {{ page.extra.author }}</span>
+      <span class="author">Skrevet av {{ page.authors | join(sep=", ") }}</span>
     {% endif %}
 </div>
   {{ page.content | safe }}


### PR DESCRIPTION
This makes it the author visable in the RSS-feed

Signed-off-by: Tim Hårek Andreassen <tim@harek.no>
